### PR TITLE
Fix not connect zerorpc when run check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenlon-mmsk",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "",
   "main": "lib/index.js",
   "types": "src/globals.d.ts",

--- a/src/check/index.ts
+++ b/src/check/index.ts
@@ -7,6 +7,7 @@ import checkPairs from './pairs'
 import checkIndicativePrice from './indicativePrice'
 import checkPrice from './price'
 import checkDeal from './deal'
+import { connectClient } from '../request/marketMaker/zerorpc'
 
 export const checkMMSK = async (config: ConfigForStart) => {
   const arr = [
@@ -31,6 +32,9 @@ export const checkMMSK = async (config: ConfigForStart) => {
   setConfig(config)
 
   const wallet = getWallet()
+  if (config.USE_ZERORPC) {
+    connectClient(config.ZERORPC_SERVER_ENDPOINT)
+  }
   await startUpdater(wallet)
 
   for (let i = 0; i < arr.length; i += 1) {

--- a/src/router/version.ts
+++ b/src/router/version.ts
@@ -1,6 +1,6 @@
 export const version = (ctx) => {
   ctx.body = {
     result: true,
-    version: '0.2.4',
+    version: '0.2.5',
   }
 }


### PR DESCRIPTION
npm run check 用于做市商接口初步自行检查，做市商 提供 http 接口，运行OK；没有验证到 zerorpc 接口提供方式，npm run check 的运行情况。

发现 zerorpc 接口提供方式时，npm run check 的脚本，没有进行 zerorpc server 的连接，会报`HeartbeatError: Lost remote after 10000ms` 错误。


需要修复此部分处理，升级 package 至 2.4.5