### PR TITLE
Feat support multiple provider url

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokenlon-mmsk",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "description": "",
   "main": "lib/index.js",
   "types": "src/globals.d.ts",

--- a/src/router/version.ts
+++ b/src/router/version.ts
@@ -1,6 +1,6 @@
 export const version = (ctx) => {
   ctx.body = {
     result: true,
-    version: '0.2.8',
+    version: '0.3.0',
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,7 +21,7 @@ export interface Wallet {
 export interface ConfigForStart {
   EXCHANGE_URL: string
   WEBSOCKET_URL: string
-  PROVIDER_URL: string
+  PROVIDER_URL: string | string[]
 
   WALLET_ADDRESS: string
   USE_KEYSTORE?: boolean

--- a/src/utils/ethereum.ts
+++ b/src/utils/ethereum.ts
@@ -1,25 +1,21 @@
 import { BigNumber } from '0x.js'
 import { toBN } from './math'
-import { getweb3 } from './web3'
+import { web3RequestWrap } from './web3'
 import { addressWithout0x } from './address'
 import { leftPadWith0 } from './helper'
 
-export const getEthBalance = (address) => {
-  const web3 = getweb3()
-  return web3.eth.getBalance(address).then(toBN)
-}
-
 export const getTokenBalance = ({ address, contractAddress }): Promise<BigNumber> => {
-  const web3 = getweb3()
-  return new Promise((resolve, reject) => {
-    web3.eth.call({
-      to: contractAddress,
-      data: `0x70a08231${leftPadWith0(addressWithout0x(address), 64)}`,
-    }, (err, res) => {
-      if (err) {
-        return reject(err)
-      }
-      resolve(toBN(res === '0x' ? 0 : res))
+  return web3RequestWrap((web3) => {
+    return new Promise((resolve, reject) => {
+      web3.eth.call({
+        to: contractAddress,
+        data: `0x70a08231${leftPadWith0(addressWithout0x(address), 64)}`,
+      }, (err, res) => {
+        if (err) {
+          return reject(err)
+        }
+        resolve(toBN(res === '0x' ? 0 : res))
+      })
     })
   })
 }

--- a/src/utils/stomp.ts
+++ b/src/utils/stomp.ts
@@ -58,7 +58,7 @@ export default class StompForExchange {
           this.connected = true
           this.resetTriedTimes()
         },
-        async (error) => {
+        (error) => {
           tracker.captureEvent({
             message: 'disconnect',
             level: Sentry.Severity.Warning,

--- a/src/utils/tracker.ts
+++ b/src/utils/tracker.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/node'
 
 let enabled = false
+let isProd = false
 
 export const initSentry = ({ SENTRY_DSN, NODE_ENV }) => {
   Sentry.init({ dsn: SENTRY_DSN, environment: NODE_ENV ? NODE_ENV.toLowerCase() : 'development' })
@@ -8,6 +9,7 @@ export const initSentry = ({ SENTRY_DSN, NODE_ENV }) => {
 
 export const init = ({ SENTRY_DSN, NODE_ENV }) => {
   enabled = SENTRY_DSN && SENTRY_DSN.indexOf('https') !== -1 && NODE_ENV && ['DEVELOPMENT', 'STAGING', 'PRODUCTION'].includes(NODE_ENV)
+  isProd = 'PRODUCTION' === NODE_ENV
   if (enabled) {
     initSentry({ SENTRY_DSN, NODE_ENV })
   }
@@ -16,7 +18,9 @@ export const init = ({ SENTRY_DSN, NODE_ENV }) => {
 export const captureMessage = (message: string, level?: Sentry.Severity) => {
   if (enabled) {
     Sentry.captureMessage(message, level)
-  } else {
+  }
+
+  if (!enabled || (enabled && isProd)) {
     console.log(message, level)
   }
 }
@@ -24,7 +28,9 @@ export const captureMessage = (message: string, level?: Sentry.Severity) => {
 export const captureException = (error: Error) => {
   if (enabled) {
     Sentry.captureException(error)
-  } else {
+  }
+
+  if (!enabled || (enabled && isProd)) {
     console.log(error)
   }
 }
@@ -32,7 +38,9 @@ export const captureException = (error: Error) => {
 export const captureEvent = (options: Sentry.SentryEvent) => {
   if (enabled) {
     Sentry.captureEvent(options)
-  } else {
+  }
+
+  if (!enabled || (enabled && isProd)) {
     console.log(options)
   }
 }

--- a/src/utils/web3.ts
+++ b/src/utils/web3.ts
@@ -1,13 +1,28 @@
 import * as Web3Export from 'web3'
+import * as _ from 'lodash'
+import { BigNumber } from '0x.js'
 import { config } from '../config'
 
 const Web3 = Web3Export.default ? Web3Export.default : Web3Export
 
 let web3 = null
 
-export const getweb3 = () => {
-  if (!web3) {
-    web3 = new Web3(new Web3.providers.HttpProvider(config.PROVIDER_URL))
+type Handler = (web3: any) => Promise<BigNumber>
+
+export const web3RequestWrap = async (handler: Handler) => {
+  const urls = _.isArray(config.PROVIDER_URL) ? config.PROVIDER_URL : [config.PROVIDER_URL]
+  let error = null
+
+  for (let url of urls) {
+    try {
+      if (!web3 || error) {
+        web3 = new Web3(new Web3.providers.HttpProvider(url))
+      }
+      return await handler(web3)
+    } catch (e) {
+      error = e
+    }
   }
-  return web3
+
+  throw error ? error : new Error('unknown web3 error')
 }


### PR DESCRIPTION
1. track.ts 的改动，仅为 log 的优化，production 环境发送 sentry 的同时，也进行 log
2. 给 web3 请求做一层包装，如果当前 provider url 的 web3 请求失败，使用下一个 provider url 的web3 继续进行请求