### PR TITLE
Support AMMV2 protocol

### DIFF
--- a/benchmark/MockServer.ts
+++ b/benchmark/MockServer.ts
@@ -98,8 +98,8 @@ function createRPCHandler(): JsonRPC {
         contractAddress: '0x6dA0e6ABd44175f50C563cd8b860DD988A7C3433',
         decimal: 18,
         precision: 6,
-        minTradeAmount: 0.001,
-        maxTradeAmount: 1e4,
+        minTradeAmount: 0.1,
+        maxTradeAmount: 1e1,
       },
       {
         symbol: 'UNI',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@consenlabs/tokenlon-mmsk",
-  "version": "5.2.0-alpha.1",
+  "version": "5.2.0-alpha.2",
   "description": "Tokenlon market maker server kit",
   "author": "imToken PTE. LTD.",
   "license": "MIT",

--- a/src/handler/newOrder.ts
+++ b/src/handler/newOrder.ts
@@ -9,6 +9,7 @@ import { assetDataUtils } from '0x-v2-order-utils'
 import { buildSignedOrder as buildRFQV1SignedOrder } from '../signer/rfqv1'
 import { buildSignedOrder } from '../signer/pmmv5'
 import { buildSignedOrder as buildAMMV1Order } from '../signer/ammv1'
+import { buildSignedOrder as buildAMMV2Order } from '../signer/ammv2'
 import { FEE_RECIPIENT_ADDRESS } from '../constants'
 import {
   BigNumber,
@@ -84,6 +85,7 @@ async function requestMarketMaker(quoter: Quoter, query: QueryInterface) {
   const rateBody = {
     ...constructQuoteResponse(priceResult, side),
     quoteId: addQuoteIdPrefix(priceResult.quoteId),
+    payload: priceResult.payload,
   }
   return { simpleOrder, rateBody }
 }
@@ -222,6 +224,22 @@ export const newOrder = async (ctx) => {
           resp.maxAmount = tokenConfig.maxTradeAmount
         }
         resp.order = buildAMMV1Order(order, rateBody.makerAddress, config.wethContractAddress)
+        break
+      case Protocol.AMMV2:
+        {
+          const tokenSymbol = simpleOrder.base
+          const tokenConfig = tokenList.find(
+            (token) => token.symbol.toUpperCase() === tokenSymbol.toUpperCase()
+          )
+          resp.minAmount = tokenConfig.minTradeAmount
+          resp.maxAmount = tokenConfig.maxTradeAmount
+        }
+        resp.order = buildAMMV2Order(
+          order,
+          rateBody.payload,
+          rateBody.makerAddress,
+          config.wethContractAddress
+        )
         break
       case Protocol.PMMV5:
         resp.order = await buildSignedOrder(

--- a/src/handler/version.ts
+++ b/src/handler/version.ts
@@ -1,6 +1,6 @@
 export const version = (ctx) => {
   ctx.body = {
     result: true,
-    version: '5.2.0-alpha.1',
+    version: '5.2.0-alpha.2',
   }
 }

--- a/src/request/_request.ts
+++ b/src/request/_request.ts
@@ -20,22 +20,23 @@ const getHeaders = () => {
   }
 }
 
-const newError = (message, url: string) => {
+const newError = (message: any | string, url: string) => {
+  let responseMessage = ''
   if (_.isObject(message) && message.message) {
-    const error = message
+    const error: any = message
     if (_.isObject(error.response) && _.isObject(error.response.data)) {
       if (error.response.data.error) {
         message = error.response.data.error.message
       }
     } else {
-      message = `${url}: ${message.message}`
+      responseMessage = `${url}: ${message.message}`
     }
   } else {
-    message = `${url}: ${message}`
+    responseMessage = `${url}: ${message}`
   }
-  const error = new Error(message)
-  error.message = message
-  error.toString = () => message
+  const error = new Error(responseMessage)
+  error.message = responseMessage
+  error.toString = () => responseMessage
   return error
 }
 
@@ -59,7 +60,7 @@ export const sendRequest = (config): Promise<any> => {
         console.log('request error', error)
         reject(newError(error, config.url))
       })
-  }) as Promise<{ error: object; result: any }>
+  }) as Promise<{ error: unknown; result: any }>
 }
 
 export const jsonrpc = {

--- a/src/request/marketMaker/types.ts
+++ b/src/request/marketMaker/types.ts
@@ -35,6 +35,7 @@ export interface PriceApiParams extends IndicativePriceApiParams {
 
 export interface PriceApiResult extends IndicativePriceApiResult {
   quoteId: string
+  payload?: string
 }
 
 export interface NotifyOrderResult {

--- a/src/signer/ammv2.ts
+++ b/src/signer/ammv2.ts
@@ -12,12 +12,14 @@ export const buildSignedOrder = (order, payload, makerAddress, wethAddress): any
   order.makerAddress = makerAddress
   // 2. convert weth to eth
   if (makerAssetAddress === wethAddress.toLowerCase()) {
+    order.makerAssetAddress = NULL_ADDRESS
     order.makerAssetData = assetDataUtils.encodeERC20AssetData(NULL_ADDRESS)
   } else {
     order.makerAssetData = assetDataUtils.encodeERC20AssetData(makerAssetAddress)
   }
 
   if (takerAssetAddress === wethAddress.toLowerCase()) {
+    order.takerAssetAddress = NULL_ADDRESS
     order.takerAssetData = assetDataUtils.encodeERC20AssetData(NULL_ADDRESS)
   } else {
     order.takerAssetData = assetDataUtils.encodeERC20AssetData(takerAssetAddress)

--- a/src/signer/ammv2.ts
+++ b/src/signer/ammv2.ts
@@ -14,15 +14,11 @@ export const buildSignedOrder = (order, payload, makerAddress, wethAddress): any
   if (makerAssetAddress === wethAddress.toLowerCase()) {
     order.makerAssetAddress = NULL_ADDRESS
     order.makerAssetData = assetDataUtils.encodeERC20AssetData(NULL_ADDRESS)
-  } else {
-    order.makerAssetData = assetDataUtils.encodeERC20AssetData(makerAssetAddress)
   }
 
   if (takerAssetAddress === wethAddress.toLowerCase()) {
     order.takerAssetAddress = NULL_ADDRESS
     order.takerAssetData = assetDataUtils.encodeERC20AssetData(NULL_ADDRESS)
-  } else {
-    order.takerAssetData = assetDataUtils.encodeERC20AssetData(takerAssetAddress)
   }
   // NOTE: for AMM order we don't do signing here
   const signedOrder = {

--- a/src/signer/ammv2.ts
+++ b/src/signer/ammv2.ts
@@ -4,7 +4,7 @@ import * as cryptoRandomString from 'crypto-random-string'
 import { orderBNToString } from '../utils'
 import { NULL_ADDRESS } from '../constants'
 
-export const buildSignedOrder = (order, makerAddress, wethAddress): any => {
+export const buildSignedOrder = (order, payload, makerAddress, wethAddress): any => {
   const makerAssetAddress = order.makerAssetAddress.toLowerCase()
   const takerAssetAddress = order.takerAssetAddress.toLowerCase()
   // = Rewrite order fields
@@ -12,17 +12,20 @@ export const buildSignedOrder = (order, makerAddress, wethAddress): any => {
   order.makerAddress = makerAddress
   // 2. convert weth to eth
   if (makerAssetAddress === wethAddress.toLowerCase()) {
-    order.makerAssetAddress = NULL_ADDRESS
     order.makerAssetData = assetDataUtils.encodeERC20AssetData(NULL_ADDRESS)
+  } else {
+    order.makerAssetData = assetDataUtils.encodeERC20AssetData(makerAssetAddress)
   }
 
   if (takerAssetAddress === wethAddress.toLowerCase()) {
-    order.takerAssetAddress = NULL_ADDRESS
     order.takerAssetData = assetDataUtils.encodeERC20AssetData(NULL_ADDRESS)
+  } else {
+    order.takerAssetData = assetDataUtils.encodeERC20AssetData(takerAssetAddress)
   }
   // NOTE: for AMM order we don't do signing here
   const signedOrder = {
     ...order,
+    payload: payload,
     salt: generatePseudoRandomSalt(),
     makerWalletSignature: cryptoRandomString({ length: 40 }),
   }

--- a/src/signer/pmmv5.ts
+++ b/src/signer/pmmv5.ts
@@ -86,7 +86,7 @@ function signByMMPSigner(
 }
 
 // Move fee factor to salt field
-export const buildSignedOrder = async (signer: Wallet, order, userAddr, pmm) => {
+export const buildSignedOrder = async (signer: Wallet, order, userAddr, pmm): Promise<any> => {
   const feeFactor = order.feeFactor
   order.takerAddress = pmm.toLowerCase()
   order.senderAddress = pmm.toLowerCase()

--- a/src/signer/rfqv1.ts
+++ b/src/signer/rfqv1.ts
@@ -65,7 +65,7 @@ export const buildSignedOrder = async (
   userAddr: string,
   chainId: number,
   rfqAddr: string
-) => {
+): Promise<any> => {
   // inject fee factor to salt
   const feeFactor = order.feeFactor
   order.takerAddress = userAddr.toLowerCase()

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -97,6 +97,7 @@ export interface QueryInterface {
 
 export enum Protocol {
   AMMV1 = 'AMMV1',
+  AMMV2 = 'AMMV2',
   PMMV5 = 'PMMV5',
   RFQV1 = 'RFQV1',
 }


### PR DESCRIPTION
Convert AMMV2 `PriceResult` to `Order`. Introduce new `payload` field in AMMV2 protocol.

Run test:

```bash
npm test
```

Should `should signed ammv2 order by uniswap v2` in `new_order.spec.ts`. 

<img width="647" alt="Screen Shot 2021-06-17 at 5 41 53 PM" src="https://user-images.githubusercontent.com/3633098/122372679-73826680-cf93-11eb-8bb1-990e623e3681.png">