### PR TITLE
fix bignumber.js digits error

### DIFF
--- a/src/quoting.ts
+++ b/src/quoting.ts
@@ -35,14 +35,10 @@ export const constructQuoteResponse = (indicativePrice: IndicativePriceApiResult
 }
 
 // Process buy amount for WYSIWY
-function applyFeeToAmount(amount: number, feeFactor: number, precision: number) {
+export function applyFeeToAmount(amount: number, feeFactor: number, precision: number): number {
   if (isNil(amount)) return amount
-  return truncateAmount(
-    toBN(amount)
-      .dividedBy(1 - feeFactor / 10000)
-      .toString(),
-    precision
-  )
+  const rate = toBN(1).sub(toBN(feeFactor).div(10000))
+  return truncateAmount(toBN(amount).dividedBy(rate).toString(), precision)
 }
 
 function calcFeeFactorWhenBuy(tokenCfg: TokenConfig, factor: number | null): number {

--- a/test/quoting.spec.ts
+++ b/test/quoting.spec.ts
@@ -1,0 +1,10 @@
+import 'mocha'
+import { assert } from 'chai'
+import { applyFeeToAmount } from '../src/quoting'
+
+describe('quoting.ts', function () {
+  it('applyFeeToAmount', function () {
+    const fee = applyFeeToAmount(104, 2553, 6)
+    assert.equal(fee, 139.653551)
+  })
+})


### PR DESCRIPTION
修复newOrder过程中bignumber.js报出的digits error。原本想要祛除从0x-util中引用bignumber.js，但测试下来会影响到pmmv5订单的签出。因为0x-v2-order-utils与0x-v2-utils都会有依赖bignumber.js，所以，临时先解决报错的问题。至于切换bignumber.js则可以等到rfq全量上线，到时自然可以去掉0x相关依赖。