### PR TITLE
Feature/testing mmsk with sdk and hardhat

### DIFF
--- a/contracts/MMP.sol
+++ b/contracts/MMP.sol
@@ -1,0 +1,1040 @@
+/**
+ *Submitted for verification at Etherscan.io on 2021-12-07
+*/
+
+pragma solidity ^0.5.0;
+
+contract IOwnable {
+  function transferOwnership(address newOwner) public;
+
+  function setOperator(address newOwner) public;
+}
+
+contract Ownable is
+  IOwnable
+{
+  address public owner;
+  address public operator;
+
+  constructor ()
+    public
+  {
+    owner = msg.sender;
+  }
+
+  modifier onlyOwner() {
+    require(
+      msg.sender == owner,
+      "ONLY_CONTRACT_OWNER"
+    );
+    _;
+  }
+
+  modifier onlyOperator() {
+    require(
+      msg.sender == operator,
+      "ONLY_CONTRACT_OPERATOR"
+    );
+    _;
+  }
+
+  function transferOwnership(address newOwner)
+    public
+    onlyOwner
+  {
+    if (newOwner != address(0)) {
+      owner = newOwner;
+    }
+  }
+
+  function setOperator(address newOperator)
+    public
+    onlyOwner 
+  {
+    operator = newOperator;
+  }
+}
+
+pragma experimental ABIEncoderV2;
+
+contract LibEIP712 {
+
+    // EIP191 header for EIP712 prefix
+    string constant internal EIP191_HEADER = "\x19\x01";
+
+    // EIP712 Domain Name value
+    string constant internal EIP712_DOMAIN_NAME = "0x Protocol";
+
+    // EIP712 Domain Version value
+    string constant internal EIP712_DOMAIN_VERSION = "2";
+
+    // Hash of the EIP712 Domain Separator Schema
+    bytes32 constant internal EIP712_DOMAIN_SEPARATOR_SCHEMA_HASH = keccak256(abi.encodePacked(
+        "EIP712Domain(",
+        "string name,",
+        "string version,",
+        "address verifyingContract",
+        ")"
+    ));
+
+    // Hash of the EIP712 Domain Separator data
+    // solhint-disable-next-line var-name-mixedcase
+    bytes32 public EIP712_DOMAIN_HASH;
+
+    constructor ()
+        public
+    {
+        EIP712_DOMAIN_HASH = keccak256(abi.encodePacked(
+            EIP712_DOMAIN_SEPARATOR_SCHEMA_HASH,
+            keccak256(bytes(EIP712_DOMAIN_NAME)),
+            keccak256(bytes(EIP712_DOMAIN_VERSION)),
+            bytes12(0),
+            address(this)
+        ));
+    }
+
+    /// @dev Calculates EIP712 encoding for a hash struct in this EIP712 Domain.
+    /// @param hashStruct The EIP712 hash struct.
+    /// @return EIP712 hash applied to this EIP712 Domain.
+    function hashEIP712Message(bytes32 hashStruct)
+        internal
+        view
+        returns (bytes32 result)
+    {
+        bytes32 eip712DomainHash = EIP712_DOMAIN_HASH;
+
+        // Assembly for more efficient computing:
+        // keccak256(abi.encodePacked(
+        //     EIP191_HEADER,
+        //     EIP712_DOMAIN_HASH,
+        //     hashStruct    
+        // ));
+
+        assembly {
+            // Load free memory pointer
+            let memPtr := mload(64)
+
+            mstore(memPtr, 0x1901000000000000000000000000000000000000000000000000000000000000)  // EIP191 header
+            mstore(add(memPtr, 2), eip712DomainHash)                                            // EIP712 domain hash
+            mstore(add(memPtr, 34), hashStruct)                                                 // Hash of struct
+
+            // Compute hash
+            result := keccak256(memPtr, 66)
+        }
+        return result;
+    }
+}
+
+contract LibOrder is
+    LibEIP712
+{
+    // Hash for the EIP712 Order Schema
+    bytes32 constant internal EIP712_ORDER_SCHEMA_HASH = keccak256(abi.encodePacked(
+        "Order(",
+        "address makerAddress,",
+        "address takerAddress,",
+        "address feeRecipientAddress,",
+        "address senderAddress,",
+        "uint256 makerAssetAmount,",
+        "uint256 takerAssetAmount,",
+        "uint256 makerFee,",
+        "uint256 takerFee,",
+        "uint256 expirationTimeSeconds,",
+        "uint256 salt,",
+        "bytes makerAssetData,",
+        "bytes takerAssetData",
+        ")"
+    ));
+
+    // A valid order remains fillable until it is expired, fully filled, or cancelled.
+    // An order's state is unaffected by external factors, like account balances.
+    enum OrderStatus {
+        INVALID,                     // Default value
+        INVALID_MAKER_ASSET_AMOUNT,  // Order does not have a valid maker asset amount
+        INVALID_TAKER_ASSET_AMOUNT,  // Order does not have a valid taker asset amount
+        FILLABLE,                    // Order is fillable
+        EXPIRED,                     // Order has already expired
+        FULLY_FILLED,                // Order is fully filled
+        CANCELLED                    // Order has been cancelled
+    }
+
+    // solhint-disable max-line-length
+    struct Order {
+        address makerAddress;           // Address that created the order.      
+        address takerAddress;           // Address that is allowed to fill the order. If set to 0, any address is allowed to fill the order.          
+        address feeRecipientAddress;    // Address that will recieve fees when order is filled.      
+        address senderAddress;          // Address that is allowed to call Exchange contract methods that affect this order. If set to 0, any address is allowed to call these methods.
+        uint256 makerAssetAmount;       // Amount of makerAsset being offered by maker. Must be greater than 0.        
+        uint256 takerAssetAmount;       // Amount of takerAsset being bid on by maker. Must be greater than 0.        
+        uint256 makerFee;               // Amount of ZRX paid to feeRecipient by maker when order is filled. If set to 0, no transfer of ZRX from maker to feeRecipient will be attempted.
+        uint256 takerFee;               // Amount of ZRX paid to feeRecipient by taker when order is filled. If set to 0, no transfer of ZRX from taker to feeRecipient will be attempted.
+        uint256 expirationTimeSeconds;  // Timestamp in seconds at which order expires.          
+        uint256 salt;                   // Arbitrary number to facilitate uniqueness of the order's hash.     
+        bytes makerAssetData;           // Encoded data that can be decoded by a specified proxy contract when transferring makerAsset. The last byte references the id of this proxy.
+        bytes takerAssetData;           // Encoded data that can be decoded by a specified proxy contract when transferring takerAsset. The last byte references the id of this proxy.
+    }
+    // solhint-enable max-line-length
+
+    struct OrderInfo {
+        uint8 orderStatus;                    // Status that describes order's validity and fillability.
+        bytes32 orderHash;                    // EIP712 hash of the order (see LibOrder.getOrderHash).
+        uint256 orderTakerAssetFilledAmount;  // Amount of order that has already been filled.
+    }
+
+    /// @dev Calculates Keccak-256 hash of the order.
+    /// @param order The order structure.
+    /// @return Keccak-256 EIP712 hash of the order.
+    function getOrderHash(Order memory order)
+        internal
+        view
+        returns (bytes32 orderHash)
+    {
+        orderHash = hashEIP712Message(hashOrder(order));
+        return orderHash;
+    }
+
+    /// @dev Calculates EIP712 hash of the order.
+    /// @param order The order structure.
+    /// @return EIP712 hash of the order.
+    function hashOrder(Order memory order)
+        internal
+        pure
+        returns (bytes32 result)
+    {
+        bytes32 schemaHash = EIP712_ORDER_SCHEMA_HASH;
+        bytes32 makerAssetDataHash = keccak256(order.makerAssetData);
+        bytes32 takerAssetDataHash = keccak256(order.takerAssetData);
+
+        // Assembly for more efficiently computing:
+        // keccak256(abi.encodePacked(
+        //     EIP712_ORDER_SCHEMA_HASH,
+        //     bytes32(order.makerAddress),
+        //     bytes32(order.takerAddress),
+        //     bytes32(order.feeRecipientAddress),
+        //     bytes32(order.senderAddress),
+        //     order.makerAssetAmount,
+        //     order.takerAssetAmount,
+        //     order.makerFee,
+        //     order.takerFee,
+        //     order.expirationTimeSeconds,
+        //     order.salt,
+        //     keccak256(order.makerAssetData),
+        //     keccak256(order.takerAssetData)
+        // ));
+
+        assembly {
+            // Calculate memory addresses that will be swapped out before hashing
+            let pos1 := sub(order, 32)
+            let pos2 := add(order, 320)
+            let pos3 := add(order, 352)
+
+            // Backup
+            let temp1 := mload(pos1)
+            let temp2 := mload(pos2)
+            let temp3 := mload(pos3)
+            
+            // Hash in place
+            mstore(pos1, schemaHash)
+            mstore(pos2, makerAssetDataHash)
+            mstore(pos3, takerAssetDataHash)
+            result := keccak256(pos1, 416)
+            
+            // Restore
+            mstore(pos1, temp1)
+            mstore(pos2, temp2)
+            mstore(pos3, temp3)
+        }
+        return result;
+    }
+}
+
+library LibBytes {
+
+    using LibBytes for bytes;
+
+    /// @dev Gets the memory address for a byte array.
+    /// @param input Byte array to lookup.
+    /// @return memoryAddress Memory address of byte array. This
+    ///         points to the header of the byte array which contains
+    ///         the length.
+    function rawAddress(bytes memory input)
+        internal
+        pure
+        returns (uint256 memoryAddress)
+    {
+        assembly {
+            memoryAddress := input
+        }
+        return memoryAddress;
+    }
+    
+    /// @dev Gets the memory address for the contents of a byte array.
+    /// @param input Byte array to lookup.
+    /// @return memoryAddress Memory address of the contents of the byte array.
+    function contentAddress(bytes memory input)
+        internal
+        pure
+        returns (uint256 memoryAddress)
+    {
+        assembly {
+            memoryAddress := add(input, 32)
+        }
+        return memoryAddress;
+    }
+
+    /// @dev Copies `length` bytes from memory location `source` to `dest`.
+    /// @param dest memory address to copy bytes to.
+    /// @param source memory address to copy bytes from.
+    /// @param length number of bytes to copy.
+    function memCopy(
+        uint256 dest,
+        uint256 source,
+        uint256 length
+    )
+        internal
+        pure
+    {
+        if (length < 32) {
+            // Handle a partial word by reading destination and masking
+            // off the bits we are interested in.
+            // This correctly handles overlap, zero lengths and source == dest
+            assembly {
+                let mask := sub(exp(256, sub(32, length)), 1)
+                let s := and(mload(source), not(mask))
+                let d := and(mload(dest), mask)
+                mstore(dest, or(s, d))
+            }
+        } else {
+            // Skip the O(length) loop when source == dest.
+            if (source == dest) {
+                return;
+            }
+
+            // For large copies we copy whole words at a time. The final
+            // word is aligned to the end of the range (instead of after the
+            // previous) to handle partial words. So a copy will look like this:
+            //
+            //  ####
+            //      ####
+            //          ####
+            //            ####
+            //
+            // We handle overlap in the source and destination range by
+            // changing the copying direction. This prevents us from
+            // overwriting parts of source that we still need to copy.
+            //
+            // This correctly handles source == dest
+            //
+            if (source > dest) {
+                assembly {
+                    // We subtract 32 from `sEnd` and `dEnd` because it
+                    // is easier to compare with in the loop, and these
+                    // are also the addresses we need for copying the
+                    // last bytes.
+                    length := sub(length, 32)
+                    let sEnd := add(source, length)
+                    let dEnd := add(dest, length)
+
+                    // Remember the last 32 bytes of source
+                    // This needs to be done here and not after the loop
+                    // because we may have overwritten the last bytes in
+                    // source already due to overlap.
+                    let last := mload(sEnd)
+
+                    // Copy whole words front to back
+                    // Note: the first check is always true,
+                    // this could have been a do-while loop.
+                    // solhint-disable-next-line no-empty-blocks
+                    for {} lt(source, sEnd) {} {
+                        mstore(dest, mload(source))
+                        source := add(source, 32)
+                        dest := add(dest, 32)
+                    }
+                    
+                    // Write the last 32 bytes
+                    mstore(dEnd, last)
+                }
+            } else {
+                assembly {
+                    // We subtract 32 from `sEnd` and `dEnd` because those
+                    // are the starting points when copying a word at the end.
+                    length := sub(length, 32)
+                    let sEnd := add(source, length)
+                    let dEnd := add(dest, length)
+
+                    // Remember the first 32 bytes of source
+                    // This needs to be done here and not after the loop
+                    // because we may have overwritten the first bytes in
+                    // source already due to overlap.
+                    let first := mload(source)
+
+                    // Copy whole words back to front
+                    // We use a signed comparisson here to allow dEnd to become
+                    // negative (happens when source and dest < 32). Valid
+                    // addresses in local memory will never be larger than
+                    // 2**255, so they can be safely re-interpreted as signed.
+                    // Note: the first check is always true,
+                    // this could have been a do-while loop.
+                    // solhint-disable-next-line no-empty-blocks
+                    for {} slt(dest, dEnd) {} {
+                        mstore(dEnd, mload(sEnd))
+                        sEnd := sub(sEnd, 32)
+                        dEnd := sub(dEnd, 32)
+                    }
+                    
+                    // Write the first 32 bytes
+                    mstore(dest, first)
+                }
+            }
+        }
+    }
+
+    /// @dev Returns a slices from a byte array.
+    /// @param b The byte array to take a slice from.
+    /// @param from The starting index for the slice (inclusive).
+    /// @param to The final index for the slice (exclusive).
+    /// @return result The slice containing bytes at indices [from, to)
+    function slice(
+        bytes memory b,
+        uint256 from,
+        uint256 to
+    )
+        internal
+        pure
+        returns (bytes memory result)
+    {
+        require(
+            from <= to,
+            "FROM_LESS_THAN_TO_REQUIRED"
+        );
+        require(
+            to < b.length,
+            "TO_LESS_THAN_LENGTH_REQUIRED"
+        );
+        
+        // Create a new bytes structure and copy contents
+        result = new bytes(to - from);
+        memCopy(
+            result.contentAddress(),
+            b.contentAddress() + from,
+            result.length
+        );
+        return result;
+    }
+    
+    /// @dev Returns a slice from a byte array without preserving the input.
+    /// @param b The byte array to take a slice from. Will be destroyed in the process.
+    /// @param from The starting index for the slice (inclusive).
+    /// @param to The final index for the slice (exclusive).
+    /// @return result The slice containing bytes at indices [from, to)
+    /// @dev When `from == 0`, the original array will match the slice. In other cases its state will be corrupted.
+    function sliceDestructive(
+        bytes memory b,
+        uint256 from,
+        uint256 to
+    )
+        internal
+        pure
+        returns (bytes memory result)
+    {
+        require(
+            from <= to,
+            "FROM_LESS_THAN_TO_REQUIRED"
+        );
+        require(
+            to < b.length,
+            "TO_LESS_THAN_LENGTH_REQUIRED"
+        );
+        
+        // Create a new bytes structure around [from, to) in-place.
+        assembly {
+            result := add(b, from)
+            mstore(result, sub(to, from))
+        }
+        return result;
+    }
+
+    /// @dev Pops the last byte off of a byte array by modifying its length.
+    /// @param b Byte array that will be modified.
+    /// @return The byte that was popped off.
+    function popLastByte(bytes memory b)
+        internal
+        pure
+        returns (bytes1 result)
+    {
+        require(
+            b.length > 0,
+            "GREATER_THAN_ZERO_LENGTH_REQUIRED"
+        );
+
+        // Store last byte.
+        result = b[b.length - 1];
+
+        assembly {
+            // Decrement length of byte array.
+            let newLen := sub(mload(b), 1)
+            mstore(b, newLen)
+        }
+        return result;
+    }
+
+    /// @dev Pops the last 20 bytes off of a byte array by modifying its length.
+    /// @param b Byte array that will be modified.
+    /// @return The 20 byte address that was popped off.
+    function popLast20Bytes(bytes memory b)
+        internal
+        pure
+        returns (address result)
+    {
+        require(
+            b.length >= 20,
+            "GREATER_OR_EQUAL_TO_20_LENGTH_REQUIRED"
+        );
+
+        // Store last 20 bytes.
+        result = readAddress(b, b.length - 20);
+
+        assembly {
+            // Subtract 20 from byte array length.
+            let newLen := sub(mload(b), 20)
+            mstore(b, newLen)
+        }
+        return result;
+    }
+
+    /// @dev Tests equality of two byte arrays.
+    /// @param lhs First byte array to compare.
+    /// @param rhs Second byte array to compare.
+    /// @return True if arrays are the same. False otherwise.
+    function equals(
+        bytes memory lhs,
+        bytes memory rhs
+    )
+        internal
+        pure
+        returns (bool equal)
+    {
+        // Keccak gas cost is 30 + numWords * 6. This is a cheap way to compare.
+        // We early exit on unequal lengths, but keccak would also correctly
+        // handle this.
+        return lhs.length == rhs.length && keccak256(lhs) == keccak256(rhs);
+    }
+
+    /// @dev Reads an address from a position in a byte array.
+    /// @param b Byte array containing an address.
+    /// @param index Index in byte array of address.
+    /// @return address from byte array.
+    function readAddress(
+        bytes memory b,
+        uint256 index
+    )
+        internal
+        pure
+        returns (address result)
+    {
+        require(
+            b.length >= index + 20,  // 20 is length of address
+            "GREATER_OR_EQUAL_TO_20_LENGTH_REQUIRED"
+        );
+
+        // Add offset to index:
+        // 1. Arrays are prefixed by 32-byte length parameter (add 32 to index)
+        // 2. Account for size difference between address length and 32-byte storage word (subtract 12 from index)
+        index += 20;
+
+        // Read address from array memory
+        assembly {
+            // 1. Add index to address of bytes array
+            // 2. Load 32-byte word from memory
+            // 3. Apply 20-byte mask to obtain address
+            result := and(mload(add(b, index)), 0xffffffffffffffffffffffffffffffffffffffff)
+        }
+        return result;
+    }
+
+    /// @dev Writes an address into a specific position in a byte array.
+    /// @param b Byte array to insert address into.
+    /// @param index Index in byte array of address.
+    /// @param input Address to put into byte array.
+    function writeAddress(
+        bytes memory b,
+        uint256 index,
+        address input
+    )
+        internal
+        pure
+    {
+        require(
+            b.length >= index + 20,  // 20 is length of address
+            "GREATER_OR_EQUAL_TO_20_LENGTH_REQUIRED"
+        );
+
+        // Add offset to index:
+        // 1. Arrays are prefixed by 32-byte length parameter (add 32 to index)
+        // 2. Account for size difference between address length and 32-byte storage word (subtract 12 from index)
+        index += 20;
+
+        // Store address into array memory
+        assembly {
+            // The address occupies 20 bytes and mstore stores 32 bytes.
+            // First fetch the 32-byte word where we'll be storing the address, then
+            // apply a mask so we have only the bytes in the word that the address will not occupy.
+            // Then combine these bytes with the address and store the 32 bytes back to memory with mstore.
+
+            // 1. Add index to address of bytes array
+            // 2. Load 32-byte word from memory
+            // 3. Apply 12-byte mask to obtain extra bytes occupying word of memory where we'll store the address
+            let neighbors := and(
+                mload(add(b, index)),
+                0xffffffffffffffffffffffff0000000000000000000000000000000000000000
+            )
+            
+            // Make sure input address is clean.
+            // (Solidity does not guarantee this)
+            input := and(input, 0xffffffffffffffffffffffffffffffffffffffff)
+
+            // Store the neighbors and address into memory
+            mstore(add(b, index), xor(input, neighbors))
+        }
+    }
+
+    /// @dev Reads a bytes32 value from a position in a byte array.
+    /// @param b Byte array containing a bytes32 value.
+    /// @param index Index in byte array of bytes32 value.
+    /// @return bytes32 value from byte array.
+    function readBytes32(
+        bytes memory b,
+        uint256 index
+    )
+        internal
+        pure
+        returns (bytes32 result)
+    {
+        require(
+            b.length >= index + 32,
+            "GREATER_OR_EQUAL_TO_32_LENGTH_REQUIRED"
+        );
+
+        // Arrays are prefixed by a 256 bit length parameter
+        index += 32;
+
+        // Read the bytes32 from array memory
+        assembly {
+            result := mload(add(b, index))
+        }
+        return result;
+    }
+
+    /// @dev Writes a bytes32 into a specific position in a byte array.
+    /// @param b Byte array to insert <input> into.
+    /// @param index Index in byte array of <input>.
+    /// @param input bytes32 to put into byte array.
+    function writeBytes32(
+        bytes memory b,
+        uint256 index,
+        bytes32 input
+    )
+        internal
+        pure
+    {
+        require(
+            b.length >= index + 32,
+            "GREATER_OR_EQUAL_TO_32_LENGTH_REQUIRED"
+        );
+
+        // Arrays are prefixed by a 256 bit length parameter
+        index += 32;
+
+        // Read the bytes32 from array memory
+        assembly {
+            mstore(add(b, index), input)
+        }
+    }
+
+    /// @dev Reads a uint256 value from a position in a byte array.
+    /// @param b Byte array containing a uint256 value.
+    /// @param index Index in byte array of uint256 value.
+    /// @return uint256 value from byte array.
+    function readUint256(
+        bytes memory b,
+        uint256 index
+    )
+        internal
+        pure
+        returns (uint256 result)
+    {
+        result = uint256(readBytes32(b, index));
+        return result;
+    }
+
+    /// @dev Writes a uint256 into a specific position in a byte array.
+    /// @param b Byte array to insert <input> into.
+    /// @param index Index in byte array of <input>.
+    /// @param input uint256 to put into byte array.
+    function writeUint256(
+        bytes memory b,
+        uint256 index,
+        uint256 input
+    )
+        internal
+        pure
+    {
+        writeBytes32(b, index, bytes32(input));
+    }
+
+    /// @dev Reads an unpadded bytes4 value from a position in a byte array.
+    /// @param b Byte array containing a bytes4 value.
+    /// @param index Index in byte array of bytes4 value.
+    /// @return bytes4 value from byte array.
+    function readBytes4(
+        bytes memory b,
+        uint256 index
+    )
+        internal
+        pure
+        returns (bytes4 result)
+    {
+        require(
+            b.length >= index + 4,
+            "GREATER_OR_EQUAL_TO_4_LENGTH_REQUIRED"
+        );
+
+        // Arrays are prefixed by a 32 byte length field
+        index += 32;
+
+        // Read the bytes4 from array memory
+        assembly {
+            result := mload(add(b, index))
+            // Solidity does not require us to clean the trailing bytes.
+            // We do it anyway
+            result := and(result, 0xFFFFFFFF00000000000000000000000000000000000000000000000000000000)
+        }
+        return result;
+    }
+
+    function readBytes2(
+        bytes memory b,
+        uint256 index
+    )
+        internal
+        pure
+        returns (bytes2 result)
+    {
+        require(
+            b.length >= index + 2,
+            "GREATER_OR_EQUAL_TO_2_LENGTH_REQUIRED"
+        );
+
+        // Arrays are prefixed by a 32 byte length field
+        index += 32;
+
+        // Read the bytes4 from array memory
+        assembly {
+            result := mload(add(b, index))
+            // Solidity does not require us to clean the trailing bytes.
+            // We do it anyway
+            result := and(result, 0xFFFF000000000000000000000000000000000000000000000000000000000000)
+        }
+        return result;
+    }
+
+    /// @dev Reads nested bytes from a specific position.
+    /// @dev NOTE: the returned value overlaps with the input value.
+    ///            Both should be treated as immutable.
+    /// @param b Byte array containing nested bytes.
+    /// @param index Index of nested bytes.
+    /// @return result Nested bytes.
+    function readBytesWithLength(
+        bytes memory b,
+        uint256 index
+    )
+        internal
+        pure
+        returns (bytes memory result)
+    {
+        // Read length of nested bytes
+        uint256 nestedBytesLength = readUint256(b, index);
+        index += 32;
+
+        // Assert length of <b> is valid, given
+        // length of nested bytes
+        require(
+            b.length >= index + nestedBytesLength,
+            "GREATER_OR_EQUAL_TO_NESTED_BYTES_LENGTH_REQUIRED"
+        );
+        
+        // Return a pointer to the byte array as it exists inside `b`
+        assembly {
+            result := add(b, index)
+        }
+        return result;
+    }
+
+    /// @dev Inserts bytes at a specific position in a byte array.
+    /// @param b Byte array to insert <input> into.
+    /// @param index Index in byte array of <input>.
+    /// @param input bytes to insert.
+    function writeBytesWithLength(
+        bytes memory b,
+        uint256 index,
+        bytes memory input
+    )
+        internal
+        pure
+    {
+        // Assert length of <b> is valid, given
+        // length of input
+        require(
+            b.length >= index + 32 + input.length,  // 32 bytes to store length
+            "GREATER_OR_EQUAL_TO_NESTED_BYTES_LENGTH_REQUIRED"
+        );
+
+        // Copy <input> into <b>
+        memCopy(
+            b.contentAddress() + index,
+            input.rawAddress(), // includes length of <input>
+            input.length + 32   // +32 bytes to store <input> length
+        );
+    }
+
+    /// @dev Performs a deep copy of a byte array onto another byte array of greater than or equal length.
+    /// @param dest Byte array that will be overwritten with source bytes.
+    /// @param source Byte array to copy onto dest bytes.
+    function deepCopyBytes(
+        bytes memory dest,
+        bytes memory source
+    )
+        internal
+        pure
+    {
+        uint256 sourceLen = source.length;
+        // Dest length must be >= source length, or some bytes would not be copied.
+        require(
+            dest.length >= sourceLen,
+            "GREATER_OR_EQUAL_TO_SOURCE_BYTES_LENGTH_REQUIRED"
+        );
+        memCopy(
+            dest.contentAddress(),
+            source.contentAddress(),
+            sourceLen
+        );
+    }
+}
+
+contract LibDecoder {
+    using LibBytes for bytes;
+
+    function decodeFillOrder(bytes memory data) internal pure returns(LibOrder.Order memory order, uint256 takerFillAmount, bytes memory mmSignature) {
+        require(
+            data.length > 800,
+            "LENGTH_LESS_800"
+        );
+
+        // compare method_id
+        // 0x64a3bc15 is fillOrKillOrder's method id.
+        require(
+            data.readBytes4(0) == 0x64a3bc15,
+            "WRONG_METHOD_ID"
+        );
+        
+        bytes memory dataSlice;
+        assembly {
+            dataSlice := add(data, 4)
+        }
+        //return (order, takerFillAmount, data);
+        return abi.decode(dataSlice, (LibOrder.Order, uint256, bytes));
+
+    }
+
+    function decodeMmSignatureWithoutSign(bytes memory signature) internal pure returns(address user, uint16 feeFactor) {
+        require(
+            signature.length == 87 || signature.length == 88,
+            "LENGTH_87_REQUIRED"
+        );
+
+        user = signature.readAddress(65);
+        feeFactor = uint16(signature.readBytes2(85));
+        
+        require(
+            feeFactor < 10000,
+            "FEE_FACTOR_MORE_THEN_10000"
+        );
+
+        return (user, feeFactor);
+    }
+
+    function decodeMmSignature(bytes memory signature) internal pure returns(uint8 v, bytes32 r, bytes32 s, address user, uint16 feeFactor) {
+        (user, feeFactor) = decodeMmSignatureWithoutSign(signature);
+
+        v = uint8(signature[0]);
+        r = signature.readBytes32(1);
+        s = signature.readBytes32(33);
+
+        return (v, r, s, user, feeFactor);
+    }
+
+    function decodeUserSignatureWithoutSign(bytes memory signature) internal pure returns(address receiver) {
+        require(
+            signature.length == 85 || signature.length == 86,
+            "LENGTH_85_REQUIRED"
+        );
+        receiver = signature.readAddress(65);
+
+        return receiver;
+    }
+
+    function decodeUserSignature(bytes memory signature) internal pure returns(uint8 v, bytes32 r, bytes32 s, address receiver) {
+        receiver = decodeUserSignatureWithoutSign(signature);
+
+        v = uint8(signature[0]);
+        r = signature.readBytes32(1);
+        s = signature.readBytes32(33);
+
+        return (v, r, s, receiver);
+    }
+
+    function decodeERC20Asset(bytes memory assetData) internal pure returns(address) {
+        require(
+            assetData.length == 36,
+            "LENGTH_65_REQUIRED"
+        );
+
+        return assetData.readAddress(16);
+    }
+}
+
+/**
+ * Version of ERC20 with no return values for `transfer` and `transferFrom
+ * https://medium.com/coinmonks/missing-return-value-bug-at-least-130-tokens-affected-d67bf08521ca
+ */
+interface IERC20NonStandard {
+    function transfer(address to, uint256 value) external;
+
+    function approve(address spender, uint256 value) external;
+
+    function transferFrom(address from, address to, uint256 value) external;
+
+    function totalSupply() external view returns (uint256);
+
+    function balanceOf(address who) external view returns (uint256);
+
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}
+
+contract SafeToken {
+    function doApprove(address token, address spender, uint256 amount) internal {
+        bool result;
+
+        IERC20NonStandard(token).approve(spender, amount);
+
+        assembly {
+            switch returndatasize()
+                case 0 {                      // This is a non-standard ERC-20
+                    result := not(0)          // set result to true
+                }
+                case 32 {                     // This is a complaint ERC-20
+                    returndatacopy(0, 0, 32)
+                    result := mload(0)        // Set `result = returndata` of external call
+                }
+                default {                     // This is an excessively non-compliant ERC-20, revert.
+                    revert(0, 0)
+                }
+        }
+
+        require(
+            result,
+            "APPROVE_FAILED"
+        );
+    }
+
+    function doTransferFrom(address token, address from, address to, uint256 amount) internal {
+        bool result;
+
+        IERC20NonStandard(token).transferFrom(from, to, amount);
+
+        assembly {
+            switch returndatasize()
+                case 0 {                      // This is a non-standard ERC-20
+                    result := not(0)          // set result to true
+                }
+                case 32 {                     // This is a complaint ERC-20
+                    returndatacopy(0, 0, 32)
+                    result := mload(0)        // Set `result = returndata` of external call
+                }
+                default {                     // This is an excessively non-compliant ERC-20, revert.
+                    revert(0, 0)
+                }
+        }
+
+        require(
+            result,
+            "TRANSFER_FROM_FAILED"
+        );
+    }
+}
+
+contract MarketMakerProxy is
+    Ownable,
+    LibDecoder,
+    SafeToken
+{
+    string public version = "0.0.6";
+
+    uint256 constant MAX_UINT = 2**256 - 1;
+    address internal SIGNER;
+
+    constructor () public {
+        owner = msg.sender;
+        operator = msg.sender;
+    }
+
+    function() external payable {}
+
+    // Manage
+    function setSigner(address _signer) public onlyOperator {
+        SIGNER = _signer;
+    }
+
+    function setAllowance(address[] memory token_addrs, address spender) public onlyOperator {
+        for (uint i = 0; i < token_addrs.length; i++) {
+            address token = token_addrs[i];
+            doApprove(token, spender, MAX_UINT);
+            doApprove(token, address(this), MAX_UINT);
+        }
+    }
+
+    function closeAllowance(address[] memory token_addrs, address spender) public onlyOperator {
+        for (uint i = 0; i < token_addrs.length; i++) {
+            address token = token_addrs[i];
+            doApprove(token, spender, 0);
+            doApprove(token, address(this), 0);
+        }
+    }
+
+    function isValidSignature(bytes32 orderHash, bytes memory signature) public view returns (bytes32) {
+        require(
+            SIGNER == ecrecoverAddress(orderHash, signature),
+            "INVALID_SIGNATURE"
+        );
+        return keccak256("isValidWalletSignature(bytes32,address,bytes)");
+    }
+
+    function ecrecoverAddress(bytes32 orderHash, bytes memory signature) internal pure returns (address) {
+        (uint8 v, bytes32 r, bytes32 s, address user, uint16 feeFactor) = decodeMmSignature(signature);
+
+        return ecrecover(
+            keccak256(
+                abi.encodePacked(
+                    "\x19Ethereum Signed Message:\n54",
+                    orderHash,
+                    user,
+                    feeFactor
+                )),
+            v, r, s
+        );
+    }
+}

--- a/test/rfq_order.spec.ts
+++ b/test/rfq_order.spec.ts
@@ -1,0 +1,402 @@
+import { ethers } from 'hardhat'
+import { Wallet, utils, Contract } from 'ethers'
+import { newOrder } from '../src/handler'
+import { updaterStack, Updater } from '../src/worker'
+import { NULL_ADDRESS } from '../src/constants'
+import { Protocol } from '../src/types'
+import { SignatureType, toRFQOrder } from '../src/signer/rfqv1'
+import { getOrderSignDigest } from '../src/signer/orderHash'
+import * as ethUtils from 'ethereumjs-util'
+import {
+  Signer as TokenlonSigner,
+  AllowanceTarget,
+  USDT,
+  ABI,
+  WETH,
+  Tokenlon,
+  RFQ,
+  UserProxy,
+  AMMWrapper,
+} from '@tokenlon/sdk'
+import { expect } from 'chai'
+import * as dotenv from 'dotenv'
+dotenv.config()
+
+const userPrivateKey = process.env.USER_KEY
+const mmpSignerPrivateKey = process.env.MMP_SIGNER_KEY
+const mmpContractAddress = process.env.MMP_CONTRACT_ADDRESS
+
+console.log(`userPrivateKey: ${userPrivateKey}`)
+
+console.log(`mmpContractAddress: ${mmpContractAddress}`)
+
+describe('NewOrder', function () {
+  let chainId: number
+  let usdt: Contract
+
+  before(async () => {
+    const network = await ethers.provider.getNetwork()
+    chainId = network.chainId
+  })
+
+  beforeEach(function () {
+    const mockMarkerMakerConfigUpdater = new Updater({
+      name: 'mockMarkerMakerConfigUpdater',
+      updater() {
+        return Promise.resolve({})
+      },
+    })
+    mockMarkerMakerConfigUpdater.cacheResult = {
+      mmId: 1,
+      mmProxyContractAddress: mmpContractAddress.toLowerCase(),
+      tokenlonExchangeContractAddress: Tokenlon[chainId].toLowerCase(),
+      exchangeContractAddress: '0x30589010550762d2f0d06f650d8e8b6ade6dbf4b'.toLowerCase(),
+      userProxyContractAddress: UserProxy[chainId].toLowerCase(),
+      wethContractAddress: WETH[chainId].toLowerCase(),
+      orderExpirationSeconds: 600,
+      feeFactor: 30,
+      addressBookV5: {
+        Tokenlon: Tokenlon[chainId].toLowerCase(),
+        PMM: '0x7bd7d025D4231aAD1233967b527FFd7416410257'.toLowerCase(),
+        AMMWrapper: AMMWrapper[chainId].toLowerCase(),
+        RFQ: RFQ[chainId].toLowerCase(),
+      },
+    }
+    const mockTokenConfigsFromImtokenUpdater = new Updater({
+      name: 'mockTokenConfigsFromImtokenUpdater',
+      updater() {
+        return Promise.resolve({})
+      },
+    })
+    mockTokenConfigsFromImtokenUpdater.cacheResult = []
+    const mockTokenListUpdate = new Updater({
+      name: 'mockTokenListUpdate',
+      updater() {
+        return Promise.resolve({})
+      },
+    })
+    mockTokenListUpdate.cacheResult = [
+      {
+        symbol: 'ETH',
+        contractAddress: NULL_ADDRESS.toLowerCase(),
+        decimal: 18,
+        precision: 4,
+        minTradeAmount: 0.01,
+        maxTradeAmount: 10,
+      },
+      {
+        symbol: 'USDT',
+        contractAddress: USDT[chainId].toLowerCase(),
+        decimal: 6,
+        precision: 4,
+        minTradeAmount: 1,
+        maxTradeAmount: 1000,
+      },
+    ]
+    const mockPairsFromMMUpdater = new Updater({
+      name: 'mockPairsFromMMUpdater',
+      updater() {
+        return Promise.resolve({})
+      },
+    })
+    mockPairsFromMMUpdater.cacheResult = ['USDT/ETH']
+    updaterStack['tokenListFromImtokenUpdater'] = mockTokenListUpdate
+    updaterStack['pairsFromMMUpdater'] = mockPairsFromMMUpdater
+    updaterStack['markerMakerConfigUpdater'] = mockMarkerMakerConfigUpdater
+    updaterStack['tokenConfigsFromImtokenUpdater'] = mockTokenConfigsFromImtokenUpdater
+  })
+
+  describe('Dispatch to protocol signer', function () {
+    it('Should use specifc private key signing rfqv1 order for MMP contract', async () => {
+      const ethersNetwork = await ethers.provider.getNetwork()
+      const chainId = ethersNetwork.chainId
+      usdt = await ethers.getContractAt(ABI.IERC20, USDT[chainId])
+      const [ ethHolder ] = await ethers.getSigners()
+      const user = new ethers.Wallet(userPrivateKey, ethers.provider)
+      const userAddr = user.address.toLowerCase()
+      console.log(`userAddr: ${userAddr}`)
+      await ethHolder.sendTransaction({
+        to: userAddr,
+        value: ethers.utils.parseEther('10')
+      })
+      const mmproxy = {
+        address: mmpContractAddress
+      }
+      const mmpSigner = new Wallet(mmpSignerPrivateKey, ethers.provider)
+      console.log(`mmpSigner: ${mmpSigner.address}`)
+      // @ts-ignore
+      // await mmproxy.connect(deployer).setAllowance([USDT[chainId]], AllowanceTarget[chainId])
+      const mmproxyUsdtBalance = await usdt.balanceOf(mmproxy.address)
+      const mmproxyUsdtAllowance = await usdt.allowance(mmproxy.address, AllowanceTarget[chainId])
+      console.log(`mmproxyUsdtBalance: ${ethers.utils.formatUnits(mmproxyUsdtBalance, 6)}`)
+      console.log(`mmproxyUsdtAllowance: ${ethers.utils.formatUnits(mmproxyUsdtAllowance, 6)}`)
+      console.log(`mmproxy: ${mmproxy.address}`)
+      expect(mmproxy.address).is.not.null
+      const mockMarkerMakerConfigUpdater = new Updater({
+        name: 'mockMarkerMakerConfigUpdater',
+        updater() {
+          return Promise.resolve({})
+        },
+      })
+      const cacheResult = {
+        mmId: 1,
+        mmProxyContractAddress: mmproxy.address.toLowerCase(), // sign for v4 MMP contract
+        tokenlonExchangeContractAddress: Tokenlon[chainId].toLowerCase(),
+        exchangeContractAddress: '0x30589010550762d2f0d06f650d8e8b6ade6dbf4b'.toLowerCase(),
+        userProxyContractAddress: UserProxy[chainId].toLowerCase(),
+        wethContractAddress: WETH[chainId].toLowerCase(),
+        orderExpirationSeconds: 600,
+        feeFactor: 30,
+        addressBookV5: {
+          Tokenlon: Tokenlon[chainId].toLowerCase(),
+          PMM: '0x7bd7d025D4231aAD1233967b527FFd7416410257'.toLowerCase(),
+          AMMWrapper: AMMWrapper[chainId].toLowerCase(),
+          RFQ: RFQ[chainId].toLowerCase(),
+        },
+      }
+      console.log(`mmproxy.address: ${mmproxy.address.toLowerCase()}`)
+      mockMarkerMakerConfigUpdater.cacheResult = cacheResult
+      updaterStack['markerMakerConfigUpdater'] = mockMarkerMakerConfigUpdater
+
+      const signedOrderResp = await newOrder({
+        signer: mmpSigner,
+        chainID: chainId,
+        quoter: {
+          getPrice: () => {
+            return Promise.resolve({
+              result: true,
+              exchangeable: true,
+              minAmount: 0,
+              maxAmount: 1000,
+              price: 1,
+              quoteId: 'echo-testing-8888',
+            })
+          },
+        },
+        query: {
+          base: 'ETH',
+          quote: 'USDT',
+          side: 'SELL',
+          amount: 0.1,
+          uniqId: 'testing-1111',
+          userAddr: userAddr,
+          protocol: Protocol.RFQV1,
+        },
+      })
+
+      expect(signedOrderResp).is.not.null
+
+      // verify data object
+      const order = signedOrderResp.order
+      console.log(order)
+      expect(order).is.not.null
+      expect(order.protocol).eq(Protocol.RFQV1)
+      expect(order.quoteId).eq('1--echo-testing-8888')
+      console.log(`order.makerAddress: ${order.makerAddress.toLowerCase()}`)
+      expect(order.makerAddress).eq(mmproxy.address.toLowerCase())
+      expect(order.makerAssetAmount).eq('100000')
+      expect(order.makerAssetAddress).eq(USDT[chainId].toLowerCase())
+      expect(order.makerAssetData).eq(`0xf47261b0000000000000000000000000${USDT[chainId].toLowerCase().slice(2)}`)
+      expect(order.takerAddress).eq(userAddr.toLowerCase())
+      expect(order.takerAssetAmount).eq('100000000000000000')
+      expect(order.takerAssetAddress).eq(WETH[chainId].toLowerCase())
+      expect(order.takerAssetData).eq(`0xf47261b0000000000000000000000000${WETH[chainId].toLowerCase().slice(2)}`)
+      expect(order.senderAddress).eq(Tokenlon[chainId].toLowerCase())
+      expect(order.feeRecipientAddress).eq('0xb9e29984fe50602e7a619662ebed4f90d93824c7'.toLowerCase())
+      expect(order.exchangeAddress).eq('0x30589010550762d2f0d06f650d8e8b6ade6dbf4b'.toLowerCase())
+      // The following fields are to be compatible `Order` struct.
+      expect(order.makerFee).eq('0')
+      expect(order.takerFee).eq('0')
+      // verify signature type
+      const sigBytes = utils.arrayify(signedOrderResp.order.makerWalletSignature)
+      expect(sigBytes.length).eq(88)
+      expect(sigBytes[87]).eq(SignatureType.Wallet)
+      // verify random values
+      expect(signedOrderResp.order.salt.length > 0).is.true
+      expect(Number(signedOrderResp.order.expirationTimeSeconds) > 0).is.true
+      const rfqAddr = updaterStack['markerMakerConfigUpdater'].cacheResult.addressBookV5.RFQ
+      const orderSignDigest = getOrderSignDigest(toRFQOrder(signedOrderResp.order), chainId, rfqAddr)
+      console.log(`orderSignDigest: ${orderSignDigest}`)
+      const message = ethUtils.bufferToHex(
+        Buffer.concat([
+          ethUtils.toBuffer(orderSignDigest),
+          ethUtils.toBuffer(user.address.toLowerCase()),
+          ethUtils.toBuffer(order.feeFactor > 255 ? order.feeFactor : [0, order.feeFactor]),
+        ])
+      )
+      const v = utils.hexlify(sigBytes.slice(0, 1))
+      const r = utils.hexlify(sigBytes.slice(1, 33))
+      const s = utils.hexlify(sigBytes.slice(33, 65))
+      const recovered = utils.verifyMessage(
+        utils.arrayify(message), {
+          v: parseInt(v),
+          r: r,
+          s: s
+        }
+      )
+      let sig = await mmpSigner.signMessage(utils.arrayify(message))
+      const vrs = await ethers.utils.splitSignature(sig)
+      sig = `0x${vrs.v.toString(16)}${vrs.r.slice(2)}${vrs.s.slice(2)}`
+      const walletSign = ethUtils.bufferToHex(
+        Buffer.concat([
+          ethUtils.toBuffer(utils.arrayify(sig)).slice(0, 65),
+          ethUtils.toBuffer(userAddr.toLowerCase()),
+          ethUtils.toBuffer(order.feeFactor > 255 ? order.feeFactor : [0, order.feeFactor]),
+          ethUtils.toBuffer(SignatureType.Wallet),
+        ])
+      )
+      console.log(`walletSign: ${walletSign}`)
+      expect(walletSign).eq(order.makerWalletSignature)
+      console.log(`recovered: ${recovered.toLowerCase()}`)
+      console.log(`mmpSigner.address: ${mmpSigner.address.toLowerCase()}`)
+      expect(recovered.toLowerCase()).eq(mmpSigner.address.toLowerCase())
+      console.log(`recovered === mmpSigner.address`)
+      const tokenlonSigner = new TokenlonSigner(user)
+      const signResult = await tokenlonSigner.signOrder(order, {
+        receiverAddress: user.address
+      })
+      console.log(`signResult`)
+      console.log(signResult)
+      const userUsdtBalanceBefore = await usdt.balanceOf(user.address)
+      const txRequest = await tokenlonSigner.getRawTransactionFromOrder(signResult, {
+        receiverAddress: user.address,
+      }, {
+        gasLimit: '1000000',
+        maxFeePerGas: '100000000000',
+        maxPriorityFeePerGas: '5000000000',
+      })
+      console.log(`txRequest:`)
+      console.log(txRequest)
+      const tx = await tokenlonSigner.sendTransaction(txRequest)
+      console.log(tx)
+      const receipt = await tx.wait()
+      console.log(receipt)
+      const userUsdtBalanceAfter = await usdt.balanceOf(user.address)
+      console.log(`user got ${ethers.utils.formatUnits(userUsdtBalanceAfter.sub(userUsdtBalanceBefore), 6)} usdt`)
+      expect(Number(userUsdtBalanceAfter.sub(userUsdtBalanceBefore))).gt(0)
+    }).timeout(360000)
+
+    it('Should sign rfqv1 order by EOA', async function () {
+      const user = new ethers.Wallet(userPrivateKey, ethers.provider)
+      const userAddr = user.address.toLowerCase()
+      const mmpSigner = new Wallet(mmpSignerPrivateKey, ethers.provider)
+      const mockMarkerMakerConfigUpdater = new Updater({
+        name: 'mockMarkerMakerConfigUpdater',
+        updater() {
+          return Promise.resolve({})
+        },
+      })
+      const cacheResult = {
+        mmId: 1,
+        mmProxyContractAddress: mmpSigner.address.toLowerCase(), // sign for v4 MMP contract
+        tokenlonExchangeContractAddress: Tokenlon[chainId].toLowerCase(),
+        exchangeContractAddress: '0x30589010550762d2f0d06f650d8e8b6ade6dbf4b'.toLowerCase(),
+        userProxyContractAddress: UserProxy[chainId].toLowerCase(),
+        wethContractAddress: WETH[chainId].toLowerCase(),
+        orderExpirationSeconds: 600,
+        feeFactor: 30,
+        addressBookV5: {
+          Tokenlon: Tokenlon[chainId].toLowerCase(),
+          PMM: '0x7bd7d025D4231aAD1233967b527FFd7416410257'.toLowerCase(),
+          AMMWrapper: AMMWrapper[chainId].toLowerCase(),
+          RFQ: RFQ[chainId].toLowerCase(),
+        },
+      }
+      console.log(`mmpSigner.address: ${mmpSigner.address.toLowerCase()}`)
+      mockMarkerMakerConfigUpdater.cacheResult = cacheResult
+      updaterStack['markerMakerConfigUpdater'] = mockMarkerMakerConfigUpdater
+
+      const signedOrderResp = await newOrder({
+        signer: mmpSigner,
+        chainID: chainId,
+        quoter: {
+          getPrice: () => {
+            return Promise.resolve({
+              result: true,
+              exchangeable: true,
+              minAmount: 0,
+              maxAmount: 1000,
+              price: 1,
+              quoteId: 'echo-testing-8888',
+            })
+          },
+        },
+        query: {
+          base: 'ETH',
+          quote: 'USDT',
+          side: 'SELL',
+          amount: 0.1,
+          uniqId: 'testing-1111',
+          userAddr: userAddr,
+          protocol: Protocol.RFQV1,
+        },
+      })
+
+      expect(signedOrderResp).is.not.null
+
+      // verify data object
+      const order = signedOrderResp.order
+      expect(order).is.not.null
+      expect(order.protocol).eq(Protocol.RFQV1)
+      expect(order.quoteId).eq('1--echo-testing-8888')
+      expect(order.makerAddress).eq(mmpSigner.address.toLowerCase())
+      expect(order.makerAssetAmount).eq('100000')
+      expect(order.makerAssetAddress).eq(USDT[chainId].toLowerCase())
+      expect(
+        order.makerAssetData,
+        `0xf47261b0000000000000000000000000${USDT[chainId].toLowerCase().slice(2)}`
+      )
+      expect(order.takerAddress).eq(userAddr.toLowerCase())
+      expect(order.takerAssetAmount).eq('100000000000000000')
+      expect(order.takerAssetAddress).eq(WETH[chainId].toLowerCase())
+      expect(
+        order.takerAssetData,
+        `0xf47261b0000000000000000000000000${WETH[chainId].toLowerCase().slice(2)}`
+      )
+      expect(order.senderAddress).eq(Tokenlon[chainId].toLowerCase())
+      expect(order.feeRecipientAddress).eq('0xb9e29984fe50602e7a619662ebed4f90d93824c7')
+      expect(order.exchangeAddress).eq('0x30589010550762d2f0d06f650d8e8b6ade6dbf4b')
+      // The following fields are to be compatible `Order` struct.
+      expect(order.makerFee).eq('0')
+      expect(order.takerFee).eq('0')
+      // verify signature type
+      const sigBytes = utils.arrayify(signedOrderResp.order.makerWalletSignature)
+      expect(sigBytes.length).eq(98)
+      expect(sigBytes[97]).eq(SignatureType.EthSign)
+      // verify signature
+      const rfqAddr = updaterStack['markerMakerConfigUpdater'].cacheResult.addressBookV5.RFQ
+      const orderHash = getOrderSignDigest(toRFQOrder(signedOrderResp.order), chainId, rfqAddr)
+      const recovered = utils.verifyMessage(
+        utils.arrayify(orderHash),
+        utils.hexlify(sigBytes.slice(0, 65)),
+      )
+      expect(recovered.toLowerCase()).eq(mmpSigner.address.toLowerCase())
+      // verify random values
+      expect(signedOrderResp.order.salt.length > 0).is.true
+      expect(Number(signedOrderResp.order.expirationTimeSeconds) > 0).is.true
+      const tokenlonSigner = new TokenlonSigner(user)
+      const signResult = await tokenlonSigner.signOrder(order, {
+        receiverAddress: user.address
+      })
+      console.log(`signResult`)
+      console.log(signResult)
+      const userUsdtBalanceBefore = await usdt.balanceOf(user.address)
+      const txRequest = await tokenlonSigner.getRawTransactionFromOrder(signResult, {
+        receiverAddress: user.address,
+      }, {
+        gasLimit: '1000000',
+        maxFeePerGas: '100000000000',
+        maxPriorityFeePerGas: '5000000000',
+      })
+      console.log(`txRequest:`)
+      console.log(txRequest)
+      const tx = await tokenlonSigner.sendTransaction(txRequest)
+      console.log(tx)
+      const receipt = await tx.wait()
+      console.log(receipt)
+      const userUsdtBalanceAfter = await usdt.balanceOf(user.address)
+      console.log(`user got ${ethers.utils.formatUnits(userUsdtBalanceAfter.sub(userUsdtBalanceBefore), 6)} usdt`)
+      expect(Number(userUsdtBalanceAfter.sub(userUsdtBalanceBefore))).gt(0)
+    }).timeout(360000)
+  })
+})


### PR DESCRIPTION
dev失败案例:

```
Chain ID: 5
hardhat config
{
  "chainId": 5,
  "hardfork": "london",
  "gasPrice": "auto",
  "initialBaseFeePerGas": 1000000000,
  "forking": {
    "url": "https://eth-goerli.alchemyapi.io/v2/SApYz7Tg5O6AGUlynnxndybQ9DG7ymHt"
  }
}

  NewOrder
chainId: 5
    Dispatch to protocol signer
chainId: 5
userAddr: 0x1b1582010ee71819915d62591ec7217aff032c7e
mmpSigner: 0x7F2BD57316b02B9c7Ea4fFBc2bd7dA0e3f074bd7
mmproxyUsdtBalance: 99402.76
mmproxyUsdtAllowance: 115792089237316195423570985008687907853269984665640564039457584007913129.639935
mmproxy: 0x5827b6815fdb97774ea31e790c8503e7b9014917
ensureCorrectSymbolCase, query={"protocol":"RFQV1","base":"ETH","quote":"USDT","side":"SELL","amount":0.1,"uniqId":"testing-1111","userAddr":"0x1b1582010ee71819915d62591ec7217aff032c7e"}, result={"protocol":"RFQV1","base":"ETH","quote":"USDT","side":"SELL","amount":0.1,"uniqId":"testing-1111","userAddr":"0x1b1582010ee71819915d62591ec7217aff032c7e","baseAddress":"0x0000000000000000000000000000000000000000","quoteAddress":"0xa93ef9215b907c19e739e2214e1aa5412a0401b5"}
got result from market maker {
  query: {
    protocol: 'RFQV1',
    base: 'ETH',
    quote: 'USDT',
    side: 'SELL',
    amount: 0.1,
    uniqId: 'testing-1111',
    userAddr: '0x1b1582010ee71819915d62591ec7217aff032c7e',
    baseAddress: '0x0000000000000000000000000000000000000000',
    quoteAddress: '0xa93ef9215b907c19e739e2214e1aa5412a0401b5'
  },
  priceResult: {
    result: true,
    exchangeable: true,
    minAmount: 0,
    maxAmount: 1000,
    price: 1,
    quoteId: 'echo-testing-8888'
  }
}
rfqOrer: {"takerAddr":"0x1b1582010ee71819915d62591ec7217aff032c7e","makerAddr":"0x5827b6815fdb97774ea31e790c8503e7b9014917","takerAssetAddr":"0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6","makerAssetAddr":"0xa93ef9215b907c19e739e2214e1aa5412a0401b5","takerAssetAmount":"100000000000000000","makerAssetAmount":"100000","deadline":1640254488,"feeFactor":30,"salt":"45660806108518855115001457104617010433502073246658382268903958195775345000478"}
orderHash: 0x223233ac2a5f81d7b07ae43209ff752fe635e20ea7c106065405094177c045ac
orderSignDigest: 0x8d9484cc7caf3d4a3dde011fca3056c1ec4a1e7a4a302a40fe8c96ea254b9b32
signByMMPSigner
makerWalletSignature: 0x1bf321cf64a36f01646a141459f0ec20236d56c8116be19e6b8de6a37eaf521c6a168c11bdf7986067c2599fcbbaac47abbaec8967eae86d0fc2449b76ca8e5ea01b1582010ee71819915d62591ec7217aff032c7e001e06
{
  makerAddress: '0x5827b6815fdb97774ea31e790c8503e7b9014917',
  makerAssetAmount: '100000',
  makerAssetAddress: '0xa93ef9215b907c19e739e2214e1aa5412a0401b5',
  makerAssetData: '0xf47261b0000000000000000000000000a93ef9215b907c19e739e2214e1aa5412a0401b5',
  makerFee: '0',
  takerAddress: '0x1b1582010ee71819915d62591ec7217aff032c7e',
  takerAssetAmount: '100000000000000000',
  takerAssetAddress: '0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6',
  takerAssetData: '0xf47261b0000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2208d6',
  takerFee: '0',
  senderAddress: '0x25657705a6be20511687d483f2fccfb2d92f6033',
  feeRecipientAddress: '0xb9e29984fe50602e7a619662ebed4f90d93824c7',
  expirationTimeSeconds: '1640254488',
  exchangeAddress: '0x30589010550762d2f0d06f650d8e8b6ade6dbf4b',
  feeFactor: 30,
  salt: '45660806108518855115001457104617010433502073246658382268903958195775345000478',
  makerWalletSignature: '0x1bf321cf64a36f01646a141459f0ec20236d56c8116be19e6b8de6a37eaf521c6a168c11bdf7986067c2599fcbbaac47abbaec8967eae86d0fc2449b76ca8e5ea01b1582010ee71819915d62591ec7217aff032c7e001e06',
  quoteId: '1--echo-testing-8888',
  protocol: 'RFQV1'
}
orderHash: 0x223233ac2a5f81d7b07ae43209ff752fe635e20ea7c106065405094177c045ac
orderSignDigest: 0x8d9484cc7caf3d4a3dde011fca3056c1ec4a1e7a4a302a40fe8c96ea254b9b32
walletSign: 0x1bf321cf64a36f01646a141459f0ec20236d56c8116be19e6b8de6a37eaf521c6a168c11bdf7986067c2599fcbbaac47abbaec8967eae86d0fc2449b76ca8e5ea01b1582010ee71819915d62591ec7217aff032c7e001e06
recovered: 0x7f2bd57316b02b9c7ea4ffbc2bd7da0e3f074bd7
mmpSigner.address: 0x7f2bd57316b02b9c7ea4ffbc2bd7da0e3f074bd7
recovered === mmpSigner.address
signResult
{
  eip712SignDigest: '0xca84bb3350dff9a8bee29fb9dd3c05f2a64240ab095de84a34955b400597711a',
  executeTxHash: '0xd34d5a9139f3eb1e37958e1ef45a4fbc0f5b390207048ad565be5616122ba858',
  userSalt: '45660806108518855115001457104617010433502073246658382268903958195775345000478',
  signature: '0xe9071b2c5f20519fcfdf4201f1df98d0a32288b08a0f6dab02a93e8355fc4c915284b88fe45efe4a8c0d73300b229421da408b2eb6e5961bddb37928e1ac3a281b000000000000000000000000000000000000000000000000000000000000000002',
  order: {
    makerAddress: '0x5827b6815fdb97774ea31e790c8503e7b9014917',
    makerAssetAmount: '100000',
    makerAssetAddress: '0xa93ef9215b907c19e739e2214e1aa5412a0401b5',
    makerAssetData: '0xf47261b0000000000000000000000000a93ef9215b907c19e739e2214e1aa5412a0401b5',
    makerFee: '0',
    takerAddress: '0x1b1582010ee71819915d62591ec7217aff032c7e',
    takerAssetAmount: '100000000000000000',
    takerAssetAddress: '0xb4fbf271143f4fbf7b91a5ded31805e42b2208d6',
    takerAssetData: '0xf47261b0000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2208d6',
    takerFee: '0',
    senderAddress: '0x25657705a6be20511687d483f2fccfb2d92f6033',
    feeRecipientAddress: '0xb9e29984fe50602e7a619662ebed4f90d93824c7',
    expirationTimeSeconds: '1640254488',
    exchangeAddress: '0x30589010550762d2f0d06f650d8e8b6ade6dbf4b',
    feeFactor: 30,
    salt: '45660806108518855115001457104617010433502073246658382268903958195775345000478',
    makerWalletSignature: '0x1bf321cf64a36f01646a141459f0ec20236d56c8116be19e6b8de6a37eaf521c6a168c11bdf7986067c2599fcbbaac47abbaec8967eae86d0fc2449b76ca8e5ea01b1582010ee71819915d62591ec7217aff032c7e001e06',
    quoteId: '1--echo-testing-8888',
    protocol: 'RFQV1'
  }
}
txRequest:
{
  to: '0x25657705a6be20511687D483f2fCCfb2d92f6033',
  from: '0x1b1582010EE71819915D62591EC7217AFf032c7E',
  value: '0x016345785d8a0000',
  data: '0xa1728b0d000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000002a4eba80bce0000000000000000000000001b1582010ee71819915d62591ec7217aff032c7e0000000000000000000000005827b6815fdb97774ea31e790c8503e7b9014917000000000000000000000000b4fbf271143f4fbf7b91a5ded31805e42b2208d6000000000000000000000000a93ef9215b907c19e739e2214e1aa5412a0401b5000000000000000000000000000000000000000000000000016345785d8a000000000000000000000000000000000000000000000000000000000000000186a00000000000000000000000001b1582010ee71819915d62591ec7217aff032c7e64f319b4a17191f979469079e0d89f069a7c45ad44ab8e4bb3894cc9adf4001e0000000000000000000000000000000000000000000000000000000061c44c18000000000000000000000000000000000000000000000000000000000000001e0000000000000000000000000000000000000000000000000000000000000180000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000581bf321cf64a36f01646a141459f0ec20236d56c8116be19e6b8de6a37eaf521c6a168c11bdf7986067c2599fcbbaac47abbaec8967eae86d0fc2449b76ca8e5ea01b1582010ee71819915d62591ec7217aff032c7e001e0600000000000000000000000000000000000000000000000000000000000000000000000000000062e9071b2c5f20519fcfdf4201f1df98d0a32288b08a0f6dab02a93e8355fc4c915284b88fe45efe4a8c0d73300b229421da408b2eb6e5961bddb37928e1ac3a281b00000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',
  gasLimit: '1000000',
  maxFeePerGas: '100000000000',
  maxPriorityFeePerGas: '5000000000',
  type: 2
}

      1) Should use specifc private key signing rfqv1 order for MMP contract

  0 passing (21s)
  1 failing

  1) NewOrder
       Dispatch to protocol signer
         Should use specifc private key signing rfqv1 order for MMP contract:
     Error: VM Exception while processing transaction: reverted with reason string 'WALLET_ERROR'
      at <UnrecognizedContract>.<unknown> (0xfd474e4809e690626c67ecb7a908de4b9c464b99)
      at <UnrecognizedContract>.<unknown> (0x25657705a6be20511687d483f2fccfb2d92f6033)
      at <UnrecognizedContract>.<unknown> (0x25657705a6be20511687d483f2fccfb2d92f6033)
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
      at HardhatNode._mineBlockWithPendingTxs (node_modules/hardhat/src/internal/hardhat-network/provider/node.ts:1575:23)
      at HardhatNode.mineBlock (node_modules/hardhat/src/internal/hardhat-network/provider/node.ts:443:16)
      at EthModule._sendTransactionAndReturnHash (node_modules/hardhat/src/internal/hardhat-network/provider/modules/eth.ts:1500:18)
      at HardhatNetworkProvider.request (node_modules/hardhat/src/internal/hardhat-network/provider/provider.ts:106:18)
      at EGRDataCollectionProvider.request (node_modules/hardhat-gas-reporter/src/providers.ts:43:22)
      at EthersProviderWrapper.send (node_modules/@nomiclabs/hardhat-ethers/src/internal/ethers-provider-wrapper.ts:13:20)
```